### PR TITLE
Feat/artist portfolio

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,9 @@ import EditArtistProfilePage from './pages/artist/mypage/EditArtistProfilePage';
 import { useEffect } from 'react';
 import { checkLoggedIn } from './modules/auth';
 import HotelMyPage from './pages/hotel/mypage/HotelMyPage';
+import axios from 'axios';
+
+axios.defaults.baseURL = 'http://3.12.248.32:8000';
 
 const GlobalStyle = createGlobalStyle`
   * {
@@ -55,6 +58,7 @@ const App = () => {
         />
         <Route path='/editProfile' element={<EditArtistProfilePage />} />
         <Route path='/main' element={<RequireProfile Component={MainPage} />} />
+        {/* <Route path='/addPortfolio' e */}
         <Route path='*' element={<div>Not Found.</div>} />
       </Routes>
     </>

--- a/src/api/portfolio.js
+++ b/src/api/portfolio.js
@@ -1,0 +1,36 @@
+import axios from 'axios';
+
+// title, introduceText, link 빈칸일 경우 "" 값 넣어주기
+// images 개수 제한 없음
+// 200: 포트폴리오 추가 성공
+// 500: 에러 내용
+export const addPortfolio = async (formData) =>
+  await axios.post('portfolio/addPortfolio', {
+    headers: { 'content-type': 'multipart/form-data' },
+    data: formData,
+  });
+
+// 로그인한 유저의 포트폴리오 목록 배열 반환
+// 200: JSON 반환
+// 400: 포트폴리오를 찾을 수 없음
+// 500: 에러 내용
+export const readMyPortfolio = async () =>
+  await axios.get('/portfolio/readMyPortfolio');
+
+// 아티스트별 포트폴리오 목록 렌더링 할 때 요청
+// 파라미터로 artistAuth_id 전달
+// 200: portfolio JSON 전달
+// 400: 포트폴리오 찾을 수 없음
+// 500: 에러 내용
+export const readOtherPortfolio = async (artistAuth_id) =>
+  await axios.get(`/portfolio/readOtherPortfolio/:${artistAuth_id}`);
+
+// 특정 포트폴리오를 읽을 때 사용
+// 파라미터로 /:artistAuth_id /:portfolio_id 주기
+// 200: 해당 포트폴리오 JSON 반환
+// 400: 포트폴리오 찾을 수 없음
+// 500: 에러 내용
+export const readSpecificPortfolio = async ({ artistAuth_id, portfolio_id }) =>
+  await axios.get(
+    `/portfolio/readSpecificPortfolio/:${artistAuth_id}/:${portfolio_id}`
+  );

--- a/src/components/artist/mypage/ArtistMy.js
+++ b/src/components/artist/mypage/ArtistMy.js
@@ -1,22 +1,49 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { AiOutlineMenu } from 'react-icons/ai';
 import { Link } from 'react-router-dom';
+import portfolio from '../../../modules/portfolio';
+import { HiPlus } from 'react-icons/hi';
+import DetailPortfolio from './DetailPortfolio';
 
-const ArtistMy = ({ myArtist, artistProfileImg, artistBackImg }) => {
+const ArtistMy = ({
+  form,
+  setForm,
+  myArtist,
+  artistProfileImg,
+  artistBackImg,
+  myPortfolio,
+  onChange,
+  onAddPortfolio,
+}) => {
+  const imgRef = useRef();
+  const previewRef = useRef();
   const [isOpen, setIsOpen] = useState(false);
+  const [openDetail, setOpenDetail] = useState(false);
   const onOpenMenu = (e) => {
     setIsOpen((prev) => !prev);
   };
-
+  const handleOnChangeFiles = (e) => {
+    onChange(e);
+    const {
+      target: { files },
+    } = e;
+    if ([...files].length > 0) {
+      setOpenDetail(true);
+      const reader = new FileReader();
+      const previewImg = files[0];
+      reader.readAsDataURL(previewImg);
+      reader.onloadend = () => {
+        previewRef.current.style.backgroundImage = `url(${reader.result})`;
+      };
+    }
+  };
   return (
     <ArtistMyWrapper>
       <ArtistBgImg backgroundImage={artistBackImg.backgroundImage}>
-        <div>
-          <MenuBtn onClick={onOpenMenu}>
-            <AiOutlineMenu size='22'></AiOutlineMenu>
-          </MenuBtn>
-        </div>
+        <MenuBtn onClick={onOpenMenu}>
+          <AiOutlineMenu size='22'></AiOutlineMenu>
+        </MenuBtn>
       </ArtistBgImg>
       <ArtistInfo>
         <ArtistProfileImg
@@ -26,7 +53,17 @@ const ArtistMy = ({ myArtist, artistProfileImg, artistBackImg }) => {
         <div>{myArtist.phoneNumber}</div>
         <div>{myArtist.email}</div>
       </ArtistInfo>
-      <PortfolioList>1</PortfolioList>
+      <PortfolioList>
+        {!myPortfolio && <p>개인 포트폴리오를 추가해보세요!</p>}
+        {myPortfolio &&
+          (myPortfolio.portfolios === [] ? (
+            <p>개인 포트폴리오를 추가해보세요!</p>
+          ) : (
+            myPortfolio.portfolios.map((portfolio) => (
+              <li key={portfolio._id} image={portfolio.images[0].image}></li>
+            ))
+          ))}
+      </PortfolioList>
       <MenuTab isOpen={isOpen}>
         <ul>
           <li>
@@ -40,11 +77,36 @@ const ArtistMy = ({ myArtist, artistProfileImg, artistBackImg }) => {
         </ul>
         <BlackEmpty onClick={onOpenMenu} />
       </MenuTab>
+      <form onSubmit={onAddPortfolio}>
+        <AddPortfolioLabel>
+          <ImageInput
+            ref={imgRef}
+            name='images'
+            type='file'
+            accept='image/*'
+            onChange={handleOnChangeFiles}
+            required
+            multiple
+          />
+          <HiPlus color='white' size='25' />
+        </AddPortfolioLabel>
+        {openDetail && (
+          <DetailPortfolio
+            setOpenDetail={setOpenDetail}
+            setForm={setForm}
+            onChange={onChange}
+            form={form}
+            previewRef={previewRef}
+          />
+        )}
+      </form>
     </ArtistMyWrapper>
   );
 };
 
 const ArtistMyWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
   min-height: 100vh;
   width: 100vw;
 `;
@@ -72,12 +134,47 @@ const ArtistInfo = styled.div`
   flex-direction: column;
   justify-content: flex-end;
 `;
-const PortfolioList = styled.div`
+const PortfolioList = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, 167px);
+  grid-template-rows: repeat(auto-fit, 167px);
+  grid-gap: 18px;
   background-color: #f9f9f9;
   width: 100vw;
-  min-height: 50vh;
+  flex: auto;
+  padding: 16px;
+  box-sizing: border-box;
+  & > p {
+    margin: 30px auto 0;
+  }
+  & > li {
+    list-style: none;
+    width: 167px;
+    height: 167px;
+    /* background-image: url(${({ image }) => image}); */
+    background-color: lightgreen;
+    border-radius: 15px;
+  }
+`;
+const AddPortfolioLabel = styled.label`
+  cursor: pointer;
+  background: #181818;
+  border: none;
+  border-radius: 50%;
+  width: 68px;
+  height: 68px;
+  position: absolute;
+  bottom: 12vh;
+  left: calc(50vw - 34px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+const ImageInput = styled.input`
+  display: none;
 `;
 const MenuBtn = styled.button`
+  margin: 16px;
   cursor: pointer;
   background: none;
   border: none;

--- a/src/components/artist/mypage/DetailPortfolio.js
+++ b/src/components/artist/mypage/DetailPortfolio.js
@@ -1,0 +1,95 @@
+import React, { useEffect } from 'react';
+import styled from 'styled-components';
+import { IoArrowBack } from 'react-icons/io5';
+
+const DetailPortfolio = ({
+  setOpenDetail,
+  setForm,
+  onChange,
+  form,
+  previewRef,
+}) => {
+  const onDismiss = (e) => {
+    setOpenDetail(false);
+  };
+  useEffect(() => {
+    return () => {
+      setForm((state) => ({
+        ...state,
+        title: '',
+        introduceText: '',
+        link: '',
+        images: [],
+      }));
+    };
+  }, [setForm]);
+  return (
+    <DetailBox>
+      <Header>
+        <button
+          style={{ background: 'none', border: 'none' }}
+          onClick={onDismiss}
+        >
+          <IoArrowBack size='30' />
+        </button>
+        <button style={{ background: 'none', border: 'none' }}>완료</button>
+      </Header>
+      <PreviewBox ref={previewRef} />
+      <InputBox>
+        <label>
+          제목
+          <input name='title' value={form.title} onChange={onChange} />
+        </label>
+        <label>
+          설명 입력...
+          <TextArea
+            placeholder='설명을 써보세요!'
+            name='introduceText'
+            value={form.introduceText}
+            onChange={onChange}
+          />
+        </label>
+        <label>
+          링크 삽입
+          <input name='link' value={form.link} onChange={onChange} />
+        </label>
+      </InputBox>
+    </DetailBox>
+  );
+};
+const DetailBox = styled.div`
+  position: absolute;
+  top: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: white;
+  z-index: 99;
+`;
+const Header = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid lightgray;
+  width: 100vw;
+  height: 60px;
+  padding: 0 16px;
+  box-sizing: border-box;
+`;
+const TextArea = styled.textarea`
+  border: none;
+  width: 100vw;
+  height: 50px;
+`;
+const InputBox = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+const PreviewBox = styled.div`
+  width: 80px;
+  height: 80px;
+  border-radius: 5px;
+  background-repeat: no-repeat;
+  background-size: cover;
+  border: 1px solid lightgray;
+`;
+export default DetailPortfolio;

--- a/src/containers/artist/mypage/ArtistMyContainer.js
+++ b/src/containers/artist/mypage/ArtistMyContainer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useSelector } from 'react-redux';
@@ -8,28 +8,76 @@ import {
   getMyArtistBgImg,
   getMyArtistProfileImg,
 } from '../../../modules/myPage';
+import { addPortfolio, readMyPortfolio } from '../../../modules/portfolio';
 
 const ArtistMyContainer = () => {
-  const { myArtist, artistProfileImg, artistBackImg } = useSelector(
-    ({ myPage }) => ({
-      myArtist: myPage.myArtist,
-      artistProfileImg: myPage.artistProfileImg,
-      artistBackImg: myPage.artistBackImg,
-    })
-  );
+  const {
+    myArtist,
+    artistProfileImg,
+    artistBackImg,
+    myPortfolio,
+    myPortfolioError,
+  } = useSelector(({ myPage, portfolio }) => ({
+    myArtist: myPage.myArtist,
+    artistProfileImg: myPage.artistProfileImg,
+    artistBackImg: myPage.artistBackImg,
+    myPortfolio: portfolio.myPortfolio,
+    myPortfolioError: portfolio.myPortfolioError,
+  }));
+  const initState = {
+    title: '',
+    introduceText: '',
+    link: '',
+    images: [],
+  };
+  const [form, setForm] = useState(initState);
   const dispatch = useDispatch();
-
+  const onChange = (e) => {
+    const {
+      target: { name, value, files },
+    } = e;
+    setForm((state) => ({
+      ...state,
+      [name]: name === 'images' ? [...files] : value,
+    }));
+  };
+  const onAddPortfolio = (e) => {
+    e.preventDefault();
+    if (form.images === []) {
+      alert('사진을 추가해주세요.');
+      return;
+    }
+    const formData = new FormData();
+    form.images.forEach((image) => {
+      formData.append('images', image);
+    });
+    formData.append('title', form.title);
+    formData.append('introduceText', form.introduceText);
+    formData.append('link', form.link);
+    dispatch(addPortfolio(formData));
+  };
   // jwt 발급 오류로 안됨
-  //   useEffect(() => {
-  //     dispatch(getMyAritistProfile());
-  //     dispatch(getMyArtistProfileImg());
-  //     dispatch(getMyArtistBgImg());
-  //   }, [dispatch]);
+  // useEffect(() => {
+  //   dispatch(getMyAritistProfile());
+  //   dispatch(getMyArtistProfileImg());
+  //   dispatch(getMyArtistBgImg());
+  //   dispatch(readMyPortfolio());
+  // }, [dispatch]);
+  useEffect(() => {
+    if (myPortfolioError) {
+      console.log('myPortfolioError');
+    }
+  }, [myPortfolioError]);
   return (
     <ArtistMy
+      form={form}
+      setForm={setForm}
       myArtist={myArtist}
       artistProfileImg={artistProfileImg}
       artistBackImg={artistBackImg}
+      myPortfolio={myPortfolio}
+      onChange={onChange}
+      onAddPortfolio={onAddPortfolio}
     />
   );
 };

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -82,7 +82,7 @@ const initialState = {
   signinError: null,
   logoutSuccess: null,
   check: {
-    isArtist: false,
+    isArtist: true,
     hasProfile: true,
   },
   checkError: null,

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -4,15 +4,23 @@ import auth, { authSaga } from './auth';
 import certificate, { certificateSaga } from './certificate';
 import profile, { profileSaga } from './profile';
 import myPage, { myPageSaga } from './myPage';
+import portfolio, { portfolioSaga } from './portfolio';
 
 const rootReducer = combineReducers({
   auth,
   certificate,
   profile,
   myPage,
+  portfolio,
 });
 export function* rootSaga() {
-  yield all([authSaga(), certificateSaga(), profileSaga(), myPageSaga()]);
+  yield all([
+    authSaga(),
+    certificateSaga(),
+    profileSaga(),
+    myPageSaga(),
+    portfolioSaga(),
+  ]);
 }
 
 export default rootReducer;

--- a/src/modules/portfolio.js
+++ b/src/modules/portfolio.js
@@ -1,0 +1,105 @@
+import { createAction } from 'redux-actions';
+import { createRequestSaga } from '../lib/createRequestSaga';
+import * as portfolioAPI from '../api/portfolio';
+import { takeLatest } from 'redux-saga/effects';
+import { handleActions } from 'redux-actions';
+
+const ADD_PORTFOLIO = 'portfolio/ADD_PORTFOLIO';
+const ADD_PORTFOLIO_SUCCESS = 'portfolio/ADD_PORTFOLIO_SUCCESS';
+const ADD_PORTFOLIO_FAILURE = 'portfolio/ADD_PORTFOLIO_FAILURE';
+const READ_MY_PORTFOLIO = 'portfolio/READ_MY_PORTFOLIO';
+const READ_MY_PORTFOLIO_SUCCESS = 'portfolio/READ_MY_PORTFOLIO_SUCCESS';
+const READ_MY_PORTFOLIO_FAILURE = 'portfolio/READ_MY_PORTFOLIO_FAILURE';
+
+export const addPortfolio = createAction(ADD_PORTFOLIO, (formData) => formData);
+export const readMyPortfolio = createAction(READ_MY_PORTFOLIO);
+
+const addPortfolioSaga = createRequestSaga(
+  ADD_PORTFOLIO,
+  portfolioAPI.addPortfolio
+);
+const readMyPortfolioSaga = createRequestSaga(
+  READ_MY_PORTFOLIO,
+  portfolioAPI.readMyPortfolio
+);
+
+export function* portfolioSaga() {
+  yield takeLatest(ADD_PORTFOLIO, addPortfolioSaga);
+  yield takeLatest(READ_MY_PORTFOLIO, readMyPortfolioSaga);
+}
+const initialState = {
+  success: null,
+  error: null,
+  myPortfolio: null,
+  myPortfolioError: null,
+};
+initialState.myPortfolio = {
+  _id: '619b9803d2959b99228bf3f5',
+  artistAuth_id: '619b97fcd2959b99228bf3e9',
+  portfolios: [
+    {
+      artistAuth_id: '619b97fcd2959b99228bf3e9',
+      title: '포트폴리오 제목',
+      introduceText: '소개글',
+      link: '링크',
+      images: [
+        {
+          image:
+            'https://hackathonwinwin.s3.ap-northeast-2.amazonaws.com/4291637586955897.png',
+          _id: '619b980cd2959b99228bf3fb',
+        },
+        {
+          image:
+            'https://hackathonwinwin.s3.ap-northeast-2.amazonaws.com/8301637586955898.png',
+          _id: '619b980cd2959b99228bf3fc',
+        },
+      ],
+      _id: '619b980cd2959b99228bf3fa',
+    },
+    {
+      artistAuth_id: '619b97fcd2959b99228bf3e9',
+      title: '포트폴리오 제목',
+      introduceText: '소개글',
+      link: '링크',
+      images: [
+        {
+          image:
+            'https://hackathonwinwin.s3.ap-northeast-2.amazonaws.com/4291637586955897.png',
+          _id: '619b980cd2959b99228bf3',
+        },
+        {
+          image:
+            'https://hackathonwinwin.s3.ap-northeast-2.amazonaws.com/8301637586955898.png',
+          _id: '619b980cd2959b992f3fc',
+        },
+      ],
+      _id: '619b980cd2959b99228bf3',
+    },
+  ],
+  __v: 0,
+};
+export default handleActions(
+  {
+    [ADD_PORTFOLIO_SUCCESS]: (state, { payload: success }) => ({
+      ...state,
+      success,
+      error: null,
+    }),
+    [ADD_PORTFOLIO_FAILURE]: (state, { payload: error }) => ({
+      ...state,
+      success: null,
+      error,
+    }),
+    [READ_MY_PORTFOLIO_SUCCESS]: (state, { payload: myPortfolio }) => ({
+      ...state,
+      myPortfolio,
+      myPortfolioError: null,
+    }),
+    [READ_MY_PORTFOLIO_FAILURE]: (state, { payload: error }) => ({
+      ...state,
+      myPortfolio: null,
+      myPortfolioError: error,
+    }),
+  },
+  initialState
+);


### PR DESCRIPTION
## 아티스트 포트폴리오 업로드 기능 구현
- 아티스트 마이페이지에서 포트폴리오를 추가할 수 있다.
<img width="334" alt="스크린샷 2021-11-23 오전 2 27 15" src="https://user-images.githubusercontent.com/33178048/142907315-049ea80f-9e53-4be7-834f-262c9c582b13.png">
- 아래 캡쳐화면은 포트폴리오의 사진을 선택한 후 디테일 정보(제목, 설명, 포트폴리오에 추가하고 싶은 링크 등)을 적을 수 있는 호면
<img width="331" alt="스크린샷 2021-11-23 오전 2 27 44" src="https://user-images.githubusercontent.com/33178048/142907381-9707a450-d27b-4453-8683-35a11d11c3d4.png">

[아쉬운점]
- MUI를 잘 쓸 수 있다면 더 좋은 디자인을 할 수 있을 것이다.
- 반응형으로 잘 만들지 못해서 아쉽다.